### PR TITLE
✨Middleware

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -10,6 +10,7 @@
   "imports": {
     "@effection-contrib/test-adapter": "jsr:@effection-contrib/test-adapter@^0.1.0",
     "@std/expect": "jsr:@std/expect@^1.0.13",
+    "@std/streams": "jsr:@std/streams@^1.0.9",
     "@std/testing": "jsr:@std/testing@^1.0.9",
     "deepmerge": "npm:deepmerge@^4.3.1",
     "effection": "jsr:@effection/effection@^4.0.0-alpha.7",

--- a/deno.lock
+++ b/deno.lock
@@ -3,10 +3,16 @@
   "specifiers": {
     "jsr:@effection-contrib/test-adapter@0.1": "0.1.0",
     "jsr:@effection/effection@^4.0.0-alpha.7": "4.0.0-alpha.7",
+    "jsr:@std/assert@1": "1.0.11",
     "jsr:@std/assert@^1.0.10": "1.0.11",
     "jsr:@std/assert@^1.0.11": "1.0.11",
+    "jsr:@std/bytes@^1.0.5": "1.0.5",
+    "jsr:@std/data-structures@^1.0.6": "1.0.6",
     "jsr:@std/expect@^1.0.13": "1.0.13",
+    "jsr:@std/fs@^1.0.9": "1.0.13",
     "jsr:@std/internal@^1.0.5": "1.0.5",
+    "jsr:@std/path@^1.0.8": "1.0.8",
+    "jsr:@std/streams@^1.0.9": "1.0.9",
     "jsr:@std/testing@^1.0.9": "1.0.9",
     "npm:@types/node@*": "22.5.4",
     "npm:deepmerge@^4.3.1": "4.3.1",
@@ -33,6 +39,12 @@
         "jsr:@std/internal"
       ]
     },
+    "@std/bytes@1.0.5": {
+      "integrity": "4465dd739d7963d964c809202ebea6d5c6b8e3829ef25c6a224290fbb8a1021e"
+    },
+    "@std/data-structures@1.0.6": {
+      "integrity": "76a7fd8080c66604c0496220a791860492ab21a04a63a969c0b9a0609bbbb760"
+    },
     "@std/expect@1.0.13": {
       "integrity": "d8e236c7089cd9fcf5e6032f27dadc3db6349d0aee48c15bc71d717bca5baa42",
       "dependencies": [
@@ -40,14 +52,32 @@
         "jsr:@std/internal"
       ]
     },
+    "@std/fs@1.0.13": {
+      "integrity": "756d3ff0ade91c9e72b228e8012b6ff00c3d4a4ac9c642c4dac083536bf6c605",
+      "dependencies": [
+        "jsr:@std/path"
+      ]
+    },
     "@std/internal@1.0.5": {
       "integrity": "54a546004f769c1ac9e025abd15a76b6671ddc9687e2313b67376125650dc7ba"
+    },
+    "@std/path@1.0.8": {
+      "integrity": "548fa456bb6a04d3c1a1e7477986b6cffbce95102d0bb447c67c4ee70e0364be"
+    },
+    "@std/streams@1.0.9": {
+      "integrity": "a9d26b1988cdd7aa7b1f4b51e1c36c1557f3f252880fa6cc5b9f37078b1a5035",
+      "dependencies": [
+        "jsr:@std/bytes"
+      ]
     },
     "@std/testing@1.0.9": {
       "integrity": "9bdd4ac07cb13e7594ac30e90f6ceef7254ac83a9aeaa089be0008f33aab5cd4",
       "dependencies": [
         "jsr:@std/assert@^1.0.10",
-        "jsr:@std/internal"
+        "jsr:@std/data-structures",
+        "jsr:@std/fs",
+        "jsr:@std/internal",
+        "jsr:@std/path"
       ]
     }
   },
@@ -102,6 +132,7 @@
       "jsr:@effection/effection@^4.0.0-alpha.7",
       "jsr:@std/assert@1",
       "jsr:@std/expect@^1.0.13",
+      "jsr:@std/streams@^1.0.9",
       "jsr:@std/testing@^1.0.9",
       "npm:deepmerge@^4.3.1",
       "npm:optics-ts@^2.4.1",

--- a/lib/debug.ts
+++ b/lib/debug.ts
@@ -1,0 +1,72 @@
+import type { LSPXMiddleware } from "./types.ts";
+import { createLSPXMiddleware } from "./middleware.ts";
+
+/**
+ * This debug middleware prints handy diagnostics to stderr with
+ * every request/notification in both directions
+ */
+export function debug(): LSPXMiddleware {
+  return createLSPXMiddleware({
+    client2server: {
+      *request(req, next) {
+        let [method, ...params] = req.params;
+        console.error(
+          `--> [client2server.request]`,
+          req.agents.map((a) => a.name),
+          method,
+          params,
+        );
+        let result = yield* next(req);
+        console.error(
+          `<-- [client2server.request]`,
+          req.agents.map((a) => a.name),
+          method,
+          result,
+        );
+        return result;
+      },
+      *notify(req, next) {
+        let [method, ...params] = req.params;
+        console.error(
+          `--> [client2server.notify]`,
+          req.agents.map((a) => a.name),
+          method,
+          params,
+        );
+        let result = yield* next(req);
+        return result;
+      },
+    },
+    server2client: {
+      *request(req, next) {
+        let [method, ...params] = req.params;
+        console.error(
+          `--> [server2client.request]`,
+          req.agent.name,
+          method,
+          params,
+        );
+        let result = yield* next(req);
+        console.error(
+          `<-- [server2client.request]`,
+          req.agent.name,
+          method,
+          result,
+        );
+        return result;
+      },
+
+      *notify(req, next) {
+        let [method, ...params] = req.params;
+        console.error(
+          `--> [server2client.notify]`,
+          req.agent.name,
+          method,
+          params,
+        );
+        let result = yield* next(req);
+        return result;
+      },
+    },
+  });
+}

--- a/lib/dispatch.ts
+++ b/lib/dispatch.ts
@@ -1,5 +1,10 @@
 import { all, type Operation } from "effection";
-import type { LSPAgent, NotificationParams, RequestParams } from "./types.ts";
+import type {
+  LSPAgent,
+  RequestParams,
+  XClientNotification,
+  XClientRequest,
+} from "./types.ts";
 import deepmerge from "deepmerge";
 import { get, optic } from "optics-ts";
 import { method2capability } from "./capabilities.ts";
@@ -10,19 +15,11 @@ import {
 } from "vscode-languageserver-protocol";
 
 /**
- * An incomping request that should be delegated to some group of server
- */
-export interface RequestOptions {
-  agents: LSPAgent[];
-  params: RequestParams;
-}
-
-/**
  * Dispatch an incoming request from the client to a set of matching
  * agents, and then merge the responses from each one into a single
  * response
  */
-export function* request(options: RequestOptions): Operation<unknown> {
+export function* defaultRequest(options: XClientRequest): Operation<unknown> {
   let { agents, params } = options;
   let handler = match(agents, params);
 
@@ -42,16 +39,11 @@ export function* request(options: RequestOptions): Operation<unknown> {
   return merge(responses);
 }
 
-export interface NotificationOptions {
-  agents: LSPAgent[];
-  params: NotificationParams;
-}
-
 /**
  * Dispatch an incoming notification from the client to a set of
  * matching agents.
  */
-export function* notification(options: NotificationOptions): Operation<void> {
+export function* defaultNotify(options: XClientNotification): Operation<void> {
   let [method] = options.params;
   let handler = defaultMatch(options.agents, method);
 
@@ -75,7 +67,7 @@ export function match(agents: LSPAgent[], params: RequestParams): Match {
  * If the completion trigger is not specified as one of the triggers
  * that an agent is providing, then it will not be sent the request.
  */
-function completion(options: RequestOptions): Match {
+function completion(options: XClientRequest): Match {
   let { context } = options.params[1] as CompletionParams;
   let agents = options.agents.filter((agent) => {
     let capability = agent.capabilities.completionProvider;

--- a/lib/json-rpc-connection.ts
+++ b/lib/json-rpc-connection.ts
@@ -13,8 +13,8 @@ import {
 } from "effection";
 import * as rpc from "vscode-jsonrpc/node.js";
 import type {
+  LSPServerNotification,
   LSPServerRequest,
-  NotificationParams,
   RPCEndpoint,
 } from "./types.ts";
 import { disposable, disposableScope } from "./disposable.ts";
@@ -50,11 +50,13 @@ export function useConnection(
       rpc.createMessageConnection(readable, writable),
     );
 
-    let notifications = createSignal<NotificationParams>();
+    let notifications = createSignal<LSPServerNotification>();
     let requests = createSignal<LSPServerRequest>();
 
     yield* disposable(
-      connection.onNotification((...params) => notifications.send(params)),
+      connection.onNotification((...params) => {
+        notifications.send((execute) => execute(params));
+      }),
     );
 
     yield* disposable(connection.onRequest((...params) => {

--- a/lib/lifecycle.ts
+++ b/lib/lifecycle.ts
@@ -1,95 +1,109 @@
-import type { Operation, Stream } from "effection";
-import { all, call, createChannel } from "effection";
-import type { LSPAgent, RPCEndpoint } from "./types.ts";
+import { all, call, createContext } from "effection";
+import type { LSPAgent, LSPXMiddleware } from "./types.ts";
 import { ErrorCodes } from "vscode-jsonrpc";
 import type { InitializeResult } from "vscode-languageserver-protocol";
 import { responseError } from "./json-rpc-connection.ts";
 import * as merge from "./merge.ts";
-import * as dispatch from "./dispatch.ts";
+import { createLSPXMiddleware } from "./middleware.ts";
 
-export interface State {
-  notify: RPCEndpoint["notify"];
-  request: RPCEndpoint["request"];
+const State = createContext<LSPXMiddleware>("lspx.state", uninitialized());
+
+export function lifecycle(): LSPXMiddleware {
+  return createLSPXMiddleware({
+    client2server: {
+      *request(params, next) {
+        let state = yield* State.expect();
+        return yield* state.client2Server.request(params, next);
+      },
+      *notify(params, next) {
+        let state = yield* State.expect();
+        return yield* state.client2Server.notify(params, next);
+      },
+    },
+    server2client: {
+      *request(params, next) {
+        let state = yield* State.expect();
+        return yield* state.server2Client.request(params, next);
+      },
+      *notify(params, next) {
+        let state = yield* State.expect();
+        return yield* state.server2Client.notify(params, next);
+      },
+    },
+  });
 }
 
-export function lifecycle(
-  servers: RPCEndpoint[],
-): [State, Stream<State, void>] {
-  let states = createChannel<State, void>();
-  return [uninitializedState(servers, states.send), states];
-}
-
-function uninitializedState(
-  servers: RPCEndpoint[],
-  transition: (state: State) => Operation<void>,
-): State {
-  return {
-    *notify() {},
-    *request(params) {
-      let [method] = params;
-      if (method !== "initialize") {
-        yield* responseError(
-          ErrorCodes.ServerNotInitialized,
-          `server not initialized`,
-        );
-      }
-      let agents = yield* all(servers.map((server) =>
-        call(function* () {
-          let initialization = yield* server.request<InitializeResult>(
-            params,
+function uninitialized(): LSPXMiddleware {
+  return createLSPXMiddleware({
+    client2server: {
+      *request(options) {
+        let [method] = options.params;
+        if (method !== "initialize") {
+          yield* responseError(
+            ErrorCodes.ServerNotInitialized,
+            `server not initialized`,
           );
-          let { capabilities } = initialization;
-          return {
-            ...server,
-            initialization,
-            capabilities,
-          } as LSPAgent;
-        })
-      ));
-
-      yield* transition(initializedState(agents, transition));
-
-      return cast(merge.capabilities(agents));
-    },
-  };
-}
-
-function initializedState(
-  agents: LSPAgent[],
-  transition: (state: State) => Operation<void>,
-): State {
-  return {
-    *notify(params) {
-      yield* dispatch.notification({ agents, params });
-    },
-    *request(params) {
-      let [method] = params;
-      if (method === "initialize") {
-        yield* responseError(
-          ErrorCodes.InvalidRequest,
-          `initialize invoked twice`,
-        );
-      } else if (method === "shutdown") {
-        yield* transition(shutdownState);
-        for (let agent of agents) {
-          yield* agent.request(params);
         }
-        return cast(null);
-      }
+        let agents = yield* all(
+          options.agents.map((agent) =>
+            call(function* () {
+              let initialization = yield* agent.request<InitializeResult>(
+                options.params,
+              );
+              let { capabilities } = initialization;
+              return {
+                ...agent,
+                initialization,
+                capabilities,
+              } as LSPAgent;
+            })
+          ),
+        );
 
-      return cast(yield* dispatch.request({ agents, params }));
+        yield* State.set(initialized(agents));
+
+        return cast(merge.capabilities(agents));
+      },
     },
-  };
+  });
 }
 
-const shutdownState: State = {
-  *notify() {},
-  *request() {
-    return yield* responseError(
-      ErrorCodes.InvalidRequest,
-      `server is shut down`,
-    );
-  },
-};
+function initialized(agents: LSPAgent[]): LSPXMiddleware {
+  return createLSPXMiddleware({
+    client2server: {
+      notify(options, next) {
+        return next({ ...options, agents });
+      },
+      *request(options, next) {
+        let [method] = options.params;
+        if (method === "initialize") {
+          yield* responseError(
+            ErrorCodes.InvalidRequest,
+            `initialize invoked twice`,
+          );
+        } else if (method === "shutdown") {
+          yield* State.set(shutdown());
+          yield* all(agents.map((agent) => agent.request(options.params)));
+          return null;
+        } else {
+          return yield* next({ ...options, agents });
+        }
+      },
+    },
+  });
+}
+
+function shutdown(): LSPXMiddleware {
+  return createLSPXMiddleware({
+    client2server: {
+      *request() {
+        return yield* responseError(
+          ErrorCodes.InvalidRequest,
+          `server is shut down`,
+        );
+      },
+    },
+  });
+}
 
 const cast = <T>(value: unknown) => value as T;

--- a/lib/middleware.ts
+++ b/lib/middleware.ts
@@ -1,4 +1,5 @@
 import type { Operation } from "effection";
+import type { LSPXMiddleware } from "./types.ts";
 
 export interface Middleware<In, Out> {
   (request: In, next: (input: In) => Operation<Out>): Operation<Out>;
@@ -14,4 +15,61 @@ export function concat<A, B>(
       return (request, next) => middleware(request, (req) => rest(req, next));
     });
   }
+}
+
+export function createLSPXMiddleware(options: {
+  client2server?: {
+    request?: LSPXMiddleware["client2Server"]["request"];
+    notify?: LSPXMiddleware["client2Server"]["notify"];
+  };
+  server2client?: {
+    request?: LSPXMiddleware["server2Client"]["request"];
+    notify?: LSPXMiddleware["server2Client"]["notify"];
+  };
+}): LSPXMiddleware {
+  return {
+    client2Server: options.client2server
+      ? ({
+        request: options.client2server?.request ??
+          ((input, next) => next(input)),
+        notify: options.client2server?.notify ?? ((input, next) => next(input)),
+      })
+      : ({
+        request: (input, next) => next(input),
+        notify: (input, next) => next(input),
+      }),
+    server2Client: options.server2client
+      ? ({
+        request: options.server2client.request ??
+          ((input, next) => next(input)),
+        notify: options.server2client.notify ?? ((input, next) => next(input)),
+      })
+      : ({
+        request: (input, next) => next(input),
+        notify: (input, next) => next(input),
+      }),
+  };
+}
+
+export function combineLSPXMiddlewares(
+  middlewares: LSPXMiddleware[],
+): LSPXMiddleware {
+  return {
+    client2Server: {
+      request: concat(
+        ...middlewares.map(({ client2Server }) => client2Server.request),
+      ),
+      notify: concat(
+        ...middlewares.map(({ client2Server }) => client2Server.notify),
+      ),
+    },
+    server2Client: {
+      request: concat(
+        ...middlewares.map(({ server2Client }) => server2Client.request),
+      ),
+      notify: concat(
+        ...middlewares.map(({ server2Client }) => server2Client.notify),
+      ),
+    },
+  };
 }

--- a/lib/multiplexer.ts
+++ b/lib/multiplexer.ts
@@ -1,63 +1,74 @@
 import type { Operation } from "effection";
 import { createChannel, each, resource, spawn } from "effection";
 import type {
+  LSPAgent,
+  LSPServerNotification,
   LSPServerRequest,
-  NotificationParams,
+  LSPXMiddleware,
+  RequestParams,
   RPCEndpoint,
 } from "./types.ts";
 import { lifecycle } from "./lifecycle.ts";
+import { combineLSPXMiddlewares } from "./middleware.ts";
+import { defaultNotify, defaultRequest } from "./dispatch.ts";
 
 export interface MultiplexerOptions {
-  servers: RPCEndpoint[];
+  agents: LSPAgent[];
+  middlewares: LSPXMiddleware[];
 }
 
 export function useMultiplexer(
   options: MultiplexerOptions,
 ): Operation<RPCEndpoint> {
   return resource(function* (provide) {
-    let { servers } = options;
+    let { client2Server, server2Client } = combineLSPXMiddlewares([
+      lifecycle(),
+      ...options.middlewares,
+    ]);
 
-    let notifications = createChannel<NotificationParams>();
+    let { agents } = options;
+
+    let notifications = createChannel<LSPServerNotification>();
     let requests = createChannel<LSPServerRequest>();
 
     // forward all notifications and requests from server -> client
-    for (let server of servers) {
+    for (let agent of agents) {
       yield* spawn(function* () {
-        for (let notification of yield* each(server.notifications)) {
-          yield* notifications.send(notification);
+        for (let notification of yield* each(agent.notifications)) {
+          let middleware = server2Client.notify;
+          yield* notifications.send((execute) =>
+            notification((params) =>
+              middleware({ agent, params }, ({ params }) => execute(params))
+            )
+          );
           yield* each.next();
         }
       });
 
       yield* spawn(function* () {
-        for (let request of yield* each(server.requests)) {
-          yield* requests.send(request);
+        for (let request of yield* each(agent.requests)) {
+          let middleware = server2Client.request;
+          yield* requests.send((execute) =>
+            request((params) =>
+              middleware({ agent, params }, ({ params }) => execute(params))
+            )
+          );
           yield* each.next();
         }
       });
     }
 
-    // delegate notifications and requests from client -> server to current state
-    let [state, states] = lifecycle(servers);
-
-    yield* spawn(function* () {
-      for (state of yield* each(states)) {
-        yield* each.next();
-      }
-    });
-
     let multiplexer: RPCEndpoint = {
       notifications,
       requests,
-      notify: (params) => state.notify(params),
-      request: (params) => state.request(params),
+      notify: (params) =>
+        client2Server.notify({ agents, params }, defaultNotify),
+      request: <T>(params: RequestParams) =>
+        client2Server.request({ agents, params }, defaultRequest) as Operation<
+          T
+        >,
     };
 
     yield* provide(multiplexer);
   });
-}
-
-export interface State {
-  notify: RPCEndpoint["notify"];
-  request: RPCEndpoint["request"];
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -7,6 +7,7 @@ import type {
   InitializeResult,
   ServerCapabilities,
 } from "vscode-languageserver-protocol";
+import type { Middleware } from "./middleware.ts";
 
 /**
  * Holds a reference to the remote end of an LSP conversation. It is
@@ -23,7 +24,7 @@ export interface RPCEndpoint {
   /**
    * A stream of notifications that the remote endpoint is sending to us
    */
-  notifications: Stream<NotificationParams, void>;
+  notifications: Stream<LSPServerNotification, void>;
 
   /**
    * Send a request to the remote endpoint
@@ -41,17 +42,69 @@ export interface RPCEndpoint {
  * used to match against incoming notifications and requsets.
  */
 export interface LSPAgent extends RPCEndpoint {
+  name: string;
   initialization: InitializeResult;
   capabilities: ServerCapabilities;
 }
 
 /**
- * Represents an incoming request that the LSP server
+ * A multiplexing request dispatched from a client to multiple lsp servers
+ */
+export interface XClientRequest {
+  params: RequestParams;
+  agents: LSPAgent[];
+}
+
+/**
+ * A multiplexing notification dispatched from a client to multiple lsp servers
+ */
+export interface XClientNotification {
+  params: NotificationParams;
+  agents: LSPAgent[];
+}
+
+/**
+ * A request dispatched from one of many servers to a client.
+ */
+export interface XServerRequest {
+  params: RequestParams;
+  agent: LSPAgent;
+}
+
+/**
+ * A notification dispatched from one of many servers to a client
+ */
+export interface XServerNotification {
+  params: NotificationParams;
+  agent: LSPAgent;
+}
+
+/**
+ * Represents an incoming request that one of the LSP server agents
  * is making to the client.
  */
 export interface LSPServerRequest {
   (compute: (params: RequestParams) => Operation<unknown>): Operation<void>;
 }
 
+/**
+ * Represents an incoming notification that one of the LSP server agents
+ * is making to the client.
+ */
+export interface LSPServerNotification {
+  (compute: (params: NotificationParams) => Operation<void>): Operation<void>;
+}
+
 export type RequestParams = Parameters<StarRequestHandler>;
 export type NotificationParams = Parameters<StarNotificationHandler>;
+
+export interface LSPXMiddleware {
+  client2Server: {
+    request: Middleware<XClientRequest, unknown>;
+    notify: Middleware<XClientNotification, void>;
+  };
+  server2Client: {
+    request: Middleware<XServerRequest, unknown>;
+    notify: Middleware<XServerNotification, void>;
+  };
+}

--- a/main.ts
+++ b/main.ts
@@ -1,4 +1,4 @@
-import { each, main } from "effection";
+import { main, suspend } from "effection";
 
 import * as z from "zod";
 import { parser } from "zod-opts";
@@ -27,12 +27,8 @@ await main(function* (argv) {
   } else {
     let input = Deno.stdin.readable;
     let output = Deno.stdout.writable;
-    let lspx = yield* start({ input, output, ...opts, commands: opts.lsp });
-    for (let [method] of yield* each(lspx.notifications)) {
-      if (method === "exit") {
-        break;
-      }
-      yield* each.next();
-    }
+    yield* start({ input, output, ...opts, commands: opts.lsp });
+
+    yield* suspend();
   }
 });

--- a/main.ts
+++ b/main.ts
@@ -27,8 +27,14 @@ await main(function* (argv) {
   } else {
     let input = Deno.stdin.readable;
     let output = Deno.stdout.writable;
-    yield* start({ input, output, ...opts, commands: opts.lsp });
+    yield* start({ input, output, errput, ...opts, commands: opts.lsp });
 
     yield* suspend();
   }
 });
+
+function errput(buffer: Uint8Array): void {
+  for (let written = 0; written < buffer.length;) {
+    written += Deno.stderr.writeSync(buffer.slice(written));
+  }
+}


### PR DESCRIPTION
## Motivation

In order to have an extensible architecture that will allow us to do things like provide client capabilities that the upstream client does not provide, we need a way to insert lspx into the conversation between client and servers. An example of this is fixing the gap in the conversation between `eglot` and `vscode-eslint-language-server`. (see #3)

## Approach
This applies the middleware pattern to all communication between client and server so that a single middleware can intercept whichever messages it needs to carry out its job. Because connections are stateful and support both notification and request, there are four components to each middleware:

client to N servers:

- notify
- request

1 of N servers to client:
- notify
- request

Because the middleware contains not only the request/notification params, but also the lsp agents that are sending and receiving, it can make decisions about filtering agents before forwarding on, or it can ever respond directly without consulting the other end of the connection.

As part of this, the lifecycle that captures capabilities has been re-written as the very first middleware at the top of the stack, and it actually makes it quite a bit cleaner. The lifecycle of the LSPX server is a middleware that delegates to a "State" middleware.

### Possible Drawbacks or Risks

A hypothetical risk is that it could lead to performance problems if there is too much delegation bouncing around in the system. Another concern that could be raised is that the delegation itself makes the codebase more difficult to understand, however while that might be nominally true at the level of baseline request routing. However, the clarity it brings to actually defining the behavior of the system far outweighs that.

### TODOs and Open Questions

-  This change limits itself to the minimum required to insert the middleware into each piece of communication, but in the future we should look to extracting out the special case "completion" handler in the `defaultRequest` and implement it as middleware.