### PR TITLE
👷 re-enable publishing to JSR

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -10,7 +10,7 @@ permissions:
   id-token: write
 
 jobs:
-  publish:
+  compile:
     runs-on: ubuntu-latest
 
     strategy:
@@ -61,7 +61,7 @@ jobs:
 
   release:
     name: Create GitHub Release
-    needs: publish
+    needs: compile
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -80,3 +80,25 @@ jobs:
         with:
           files: dist/**/*.tar.gz
           token: ${{ secrets.GITHUB_TOKEN }}
+
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+
+      - name: setup deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: Get Version
+        id: vars
+        run: echo ::set-output name=version::$(echo ${{github.ref_name}} | sed 's/^v//')
+
+      - name: Build JSR
+        run: deno task build:jsr ${{steps.vars.outputs.version}}
+
+      - name: Publish JSR
+        run: deno publish --allow-dirty --token=${{secrets.JSR_TOKEN}}


### PR DESCRIPTION
## Motivation

Having many modes of installation for lspx on as many systems as possible is a good thing.

## Approach

This runs the current GitHub compile / release jobs in parallel with the JSR publication job. That way, we get the benefit of all of them.

### Possible Drawbacks or Risks

- this duplicates the versioning logic between the compilation and and the jsr publication
- Adds an installation vector that does require deno to be installed on your system. 
- You will need to make sure that if you install from deno that you pass the required runtime security flags. This could change from version to version
