### PR TITLE
chore: make compile happy again

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -8,12 +8,12 @@
     "build:jsr": "deno -A tasks/build-jsr.ts"
   },
   "imports": {
-    "@effection-contrib/test-adapter": "jsr:@effection-contrib/test-adapter@^0.1.0",
+    "@effectionx/test-adapter": "jsr:@effectionx/test-adapter@^0.1.0",
     "@std/expect": "jsr:@std/expect@^1.0.13",
     "@std/streams": "jsr:@std/streams@^1.0.9",
     "@std/testing": "jsr:@std/testing@^1.0.9",
     "deepmerge": "npm:deepmerge@^4.3.1",
-    "effection": "jsr:@effection/effection@^4.0.0-alpha.7",
+    "effection": "jsr:@effection/effection@^4.0.0-beta.2",
     "@std/assert": "jsr:@std/assert@1",
     "optics-ts": "npm:optics-ts@^2.4.1",
     "vscode-jsonrpc": "npm:vscode-jsonrpc@^8.2.1",

--- a/deno.lock
+++ b/deno.lock
@@ -1,8 +1,8 @@
 {
-  "version": "4",
+  "version": "5",
   "specifiers": {
-    "jsr:@effection-contrib/test-adapter@0.1": "0.1.0",
-    "jsr:@effection/effection@^4.0.0-alpha.7": "4.0.0-alpha.7",
+    "jsr:@effection/effection@^4.0.0-beta.2": "4.0.0-beta.2",
+    "jsr:@effectionx/test-adapter@0.1": "0.1.2",
     "jsr:@std/assert@1": "1.0.11",
     "jsr:@std/assert@^1.0.10": "1.0.11",
     "jsr:@std/assert@^1.0.11": "1.0.11",
@@ -16,7 +16,7 @@
     "jsr:@std/testing@^1.0.9": "1.0.9",
     "npm:@types/node@*": "22.5.4",
     "npm:deepmerge@^4.3.1": "4.3.1",
-    "npm:effection@4.0.0-alpha.5": "4.0.0-alpha.5",
+    "npm:effection@4.0.0-beta.2": "4.0.0-beta.2",
     "npm:optics-ts@^2.4.1": "2.4.1",
     "npm:vscode-jsonrpc@^8.2.1": "8.2.1",
     "npm:vscode-languageserver-protocol@^3.17.5": "3.17.5",
@@ -24,14 +24,17 @@
     "npm:zod@^3.24.2": "3.24.2"
   },
   "jsr": {
-    "@effection-contrib/test-adapter@0.1.0": {
-      "integrity": "1263aed6b7e6cff8655eb410a81875f633ccaf15074b9ebb375f6457394f6dd4",
+    "@effection/effection@4.0.0-alpha.7": {
+      "integrity": "bb6be892e048c784a4d0ae274a5f9197eb968e3bab15a83b7763a9b1f74a382d"
+    },
+    "@effection/effection@4.0.0-beta.2": {
+      "integrity": "d1d281fa568320535e8d7e698394851d97295393b0e62d4b17f1a205f915119a"
+    },
+    "@effectionx/test-adapter@0.1.2": {
+      "integrity": "6f3b484b1bde69591c082bd512b649e583f213af5d8b3f8d38a5e74ec4d56b01",
       "dependencies": [
         "npm:effection"
       ]
-    },
-    "@effection/effection@4.0.0-alpha.7": {
-      "integrity": "bb6be892e048c784a4d0ae274a5f9197eb968e3bab15a83b7763a9b1f74a382d"
     },
     "@std/assert@1.0.11": {
       "integrity": "2461ef3c368fe88bc60e186e7744a93112f16fd110022e113a0849e94d1c83c1",
@@ -91,8 +94,8 @@
     "deepmerge@4.3.1": {
       "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="
     },
-    "effection@4.0.0-alpha.5": {
-      "integrity": "sha512-7s8dwQF8oqOxtsUrFMRQBUOWXq23Khb/IYurwqEnSTUwsgkSgQww/9A9aBwdRQ1hMmELouy/YkvhC7e9oGQfbA=="
+    "effection@4.0.0-beta.2": {
+      "integrity": "sha512-iqEBfInNx3rB2DhQYYu6LcJ7zRn4yFo+DjUntcWNZeYWh1LiucMXb2JMiD1OA8WPgc3KOwQBxXfOwby1v34WdQ=="
     },
     "optics-ts@2.4.1": {
       "integrity": "sha512-HaYzMHvC80r7U/LqAd4hQyopDezC60PO2qF5GuIwALut2cl5rK1VWHsqTp0oqoJJWjiv6uXKqsO+Q2OO0C3MmQ=="
@@ -128,8 +131,8 @@
   },
   "workspace": {
     "dependencies": [
-      "jsr:@effection-contrib/test-adapter@0.1",
-      "jsr:@effection/effection@^4.0.0-alpha.7",
+      "jsr:@effection/effection@^4.0.0-beta.2",
+      "jsr:@effectionx/test-adapter@0.1",
       "jsr:@std/assert@1",
       "jsr:@std/expect@^1.0.13",
       "jsr:@std/streams@^1.0.9",

--- a/lib/json-rpc-connection.ts
+++ b/lib/json-rpc-connection.ts
@@ -42,6 +42,7 @@ export function useConnection(
     );
     let writable = yield* disposable(
       new rpc.StreamMessageWriter(
+        //@ts-expect-error 🤷
         Writable.fromWeb(options.write, { signal }),
       ),
     );

--- a/test/bdd.ts
+++ b/test/bdd.ts
@@ -1,7 +1,4 @@
-import {
-  createTestAdapter,
-  type TestAdapter,
-} from "@effection-contrib/test-adapter";
+import { createTestAdapter, type TestAdapter } from "@effectionx/test-adapter";
 
 import * as bdd from "@std/testing/bdd";
 

--- a/test/sim/initialize.ts
+++ b/test/sim/initialize.ts
@@ -1,6 +1,5 @@
-import { each, main } from "effection";
+import { each, main, type Operation } from "effection";
 import { useConnection } from "../../lib/json-rpc-connection.ts";
-import { constant } from "https://jsr.io/@effection/effection/4.0.0-alpha.7/lib/constant.ts";
 
 await main(function* () {
   let client = yield* useConnection({
@@ -23,3 +22,9 @@ await main(function* () {
     yield* each.next();
   }
 });
+
+function constant<T>(value: T): Operation<T> {
+  return {
+    [Symbol.iterator]: () => ({ next: () => ({ done: true, value }) }),
+  };
+}


### PR DESCRIPTION
Using deno 2.5.2, this type checking blocks me to compile.

```sh
deno task compile
Task compile deno compile -o dist/lspx --allow-env --allow-run main.ts
Check file:///[redeact]/spx/main.ts
TS2345 [ERROR]: Argument of type 'WritableStream<Uint8Array<ArrayBufferLike>>' is not assignable to parameter of type 'WritableStream<any>'.
  The types of 'getWriter().closed' are incompatible between these types.
    Type 'Promise<void>' is not assignable to type 'Promise<undefined>'.
      Type 'void' is not assignable to type 'undefined'.
        Writable.fromWeb(options.write, { signal }),
                         ~~~~~~~~~~~~~
    at file:///[redeact]/lspx/lib/json-rpc-connection.ts:45:26

error: Type checking failed.

  info: The program failed type-checking, but it still might work correctly.
  hint: Re-run with --no-check to skip type-checking.
```