### PR TITLE
fix(server): Correctly handle shell commands for LSP servers

### DIFF
--- a/lib/server.ts
+++ b/lib/server.ts
@@ -21,9 +21,9 @@ export function start(opts: LSPXOptions): Operation<RPCEndpoint> {
     let agents: LSPAgent[] = [];
 
     for (let command of opts.commands) {
-      let [exe, ...args] = command.split(/\s/g);
-      let process = yield* useDaemon(exe, {
-        args,
+      let [exe] = command.split(/\s/g);
+      let process = yield* useDaemon("/bin/sh", {
+        args: ["-c", command],
         stdin: "piped",
         stdout: "piped",
         stderr: "piped",


### PR DESCRIPTION
## Motivation
This allows users to pass complex commands as a single string, resolving the startup issues.  Previously, `lspx` was unable to launch language servers that required complex, quoted arguments. This was noticeable when trying to launch the R language server from emacs `eglot`, where the command `R --slave -e 'languageserver::run()'` would fail.

see https://github.com/thefrontside/lspx/issues/18

## Approach

This commit fixes the issue by no longer parsing the command string within `lspx`. Instead, the entire command string provided to the `--lsp` option is passed directly to a shell (`/bin/sh -c`) for execution. This delegates the responsibility of parsing to the shell, which correctly handles complex commands, quoting, and arguments.

### Alternate Designs

an alternate approach might be to leave the --lsp as-is but include the fix as a separate --lsp_shell argument. This would complicated the lspx command but would reduce risk of breaking existing working lsps.

### Possible Drawbacks or Risks

Might break other working complicated commands?

### TODOs and Open Questions

Test some other language servers

## Learning

emacs eglot configuration for the R language server should now be formatted as:
```
(add-to-list 'eglot-server-programs
             '(ess-r-mode . ("lspx" "--lsp" "R --slave -e 'languageserver::run()'")))
```

or for multiple language servers (air + languageserver)
```
   (add-to-list 'eglot-server-programs '(ess-r-mode . ("lspx" "--lsp" "air language-server" "--lsp" "R --slave -e 'languageserver::run()'")))
```

